### PR TITLE
Fix segfaults on corrupted bloomfilter files

### DIFF
--- a/fleur/fleur.c
+++ b/fleur/fleur.c
@@ -35,6 +35,8 @@ struct BloomFilter * BloomFilterFromFile(FILE* f){
     size_t elements_read = fread(&h, sizeof(h), 1, f);
     if(elements_read == 0){
         perror("Cannot read  binary file.");
+        fclose(f);
+        exit(EXIT_FAILURE);
     }
     h.version = (uint64_t)1;
     bf.h = &h;
@@ -45,6 +47,8 @@ struct BloomFilter * BloomFilterFromFile(FILE* f){
     int err = fseek(f, 0, SEEK_END);
     if(err!=0){
         perror("Cannot seek in binary file.");
+        fclose(f);
+        exit(EXIT_FAILURE);
     }
     long size = ftell(f);
     fseek(f, 48, SEEK_SET);
@@ -58,6 +62,8 @@ struct BloomFilter * BloomFilterFromFile(FILE* f){
         elements_read = fread(bf.v, sizeof(uint64_t), bf.M, f);
         if(elements_read == 0){
             perror("Cannot load bitarray.");
+            fclose(f);
+            exit(EXIT_FAILURE);
         }
 
         // Load remaining data
@@ -67,6 +73,8 @@ struct BloomFilter * BloomFilterFromFile(FILE* f){
             elements_read = fread(bf.Data, sizeof(char), bf.datasize, f);
             if(elements_read == 0){
                 perror("Cannot load bloom filter metadata.");
+                fclose(f);
+                exit(EXIT_FAILURE);
             }
             bf.Data[bf.datasize] = '\0';
         }

--- a/myutils/myutils.c
+++ b/myutils/myutils.c
@@ -7,7 +7,7 @@ char* print_bin(uint64_t n)
     static char str[65];
     uint64_t i = (uint64_t)1 << 63;
     int j = 0;
-    for (i ; i > 0; i = i / 2){
+    for (; i > 0; i = i / 2){
         if (n & i){
             str[j] = '1';
         }else{


### PR DESCRIPTION
This PR fixes some segfaults I observed using corrupted bloomfilter files (cfr 
[crash0_show.bin.gz](https://github.com/hashlookup/fleur/files/9207101/crash0_show.bin.gz)
[crash1_show.bin.gz](https://github.com/hashlookup/fleur/files/9207102/crash1_show.bin.gz)
gzipped attachments).
The idea is to exit as soon as a problem is detected.
This was tested using the "show" command.
A Clang compilation warning is also cleared.